### PR TITLE
Refactor to use BesuVersionUtils everywhere version info are required

### DIFF
--- a/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/RunnerBuilder.java
@@ -124,6 +124,7 @@ import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.services.BesuPluginContextImpl;
 import org.hyperledger.besu.services.PermissioningServiceImpl;
 import org.hyperledger.besu.services.RpcEndpointServiceImpl;
+import org.hyperledger.besu.util.BesuVersionUtils;
 import org.hyperledger.besu.util.NetworkUtility;
 
 import java.io.IOException;
@@ -644,7 +645,7 @@ public class RunnerBuilder {
             .setBindHost(p2pListenInterface)
             .setBindPort(p2pListenPort)
             .setSupportedProtocols(subProtocols)
-            .setClientId(BesuInfo.nodeName(identityString));
+            .setClientId(BesuVersionUtils.nodeName(identityString));
     networkingConfiguration.setRlpx(rlpxConfiguration).setDiscovery(discoveryConfiguration);
 
     final PeerPermissionsDenylist bannedNodes = PeerPermissionsDenylist.create();
@@ -1010,7 +1011,7 @@ public class RunnerBuilder {
                   miningCoordinator,
                   besuController.getSyncState(),
                   vertx,
-                  BesuInfo.nodeName(identityString),
+                  BesuVersionUtils.nodeName(identityString),
                   besuController.getGenesisConfigOptions(),
                   network));
     } else {
@@ -1265,9 +1266,9 @@ public class RunnerBuilder {
     final Map<String, JsonRpcMethod> methods =
         new JsonRpcMethodsFactory()
             .methods(
-                BesuInfo.nodeName(identityString),
-                BesuInfo.shortVersion(),
-                BesuInfo.commit(),
+                BesuVersionUtils.nodeName(identityString),
+                BesuVersionUtils.shortVersion(),
+                BesuVersionUtils.commit(),
                 ethNetworkConfig.networkId(),
                 besuController.getGenesisConfigOptions(),
                 network,

--- a/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/BesuCommand.java
@@ -27,7 +27,6 @@ import static org.hyperledger.besu.cli.util.CommandLineUtils.isOptionSet;
 import static org.hyperledger.besu.controller.BesuController.DATABASE_PATH;
 import static org.hyperledger.besu.ethereum.api.jsonrpc.authentication.EngineAuthService.EPHEMERAL_JWT_FILE;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.Runner;
 import org.hyperledger.besu.RunnerBuilder;
 import org.hyperledger.besu.chainexport.RlpBlockExporter;
@@ -199,6 +198,7 @@ import org.hyperledger.besu.services.TransactionPoolValidatorServiceImpl;
 import org.hyperledger.besu.services.TransactionSelectionServiceImpl;
 import org.hyperledger.besu.services.TransactionSimulationServiceImpl;
 import org.hyperledger.besu.services.kvstore.InMemoryStoragePlugin;
+import org.hyperledger.besu.util.BesuVersionUtils;
 import org.hyperledger.besu.util.EphemeryGenesisUpdater;
 import org.hyperledger.besu.util.InvalidConfigurationException;
 import org.hyperledger.besu.util.LogConfigurator;
@@ -1397,7 +1397,7 @@ public class BesuCommand implements DefaultCommandValues, Runnable {
         .getMetricsSystem()
         .createLabelledSuppliedGauge(
             StandardMetricCategory.PROCESS, "release", "Release information", "version")
-        .labels(() -> 1, BesuInfo.version());
+        .labels(() -> 1, BesuVersionUtils.version());
   }
 
   /**

--- a/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/ConfigurationOverviewBuilder.java
@@ -14,10 +14,10 @@
  */
 package org.hyperledger.besu.cli;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.ethereum.eth.transactions.TransactionPoolConfiguration;
 import org.hyperledger.besu.evm.internal.EvmConfiguration;
 import org.hyperledger.besu.services.BesuPluginContextImpl;
+import org.hyperledger.besu.util.BesuVersionUtils;
 import org.hyperledger.besu.util.log.FramedLogMessage;
 import org.hyperledger.besu.util.platform.PlatformDetector;
 
@@ -309,7 +309,7 @@ public class ConfigurationOverviewBuilder {
    */
   public String build() {
     final List<String> lines = new ArrayList<>();
-    lines.add("Besu version " + BesuInfo.class.getPackage().getImplementationVersion());
+    lines.add("Besu version " + BesuVersionUtils.version());
     lines.add("");
     lines.add("Configuration:");
 

--- a/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/BackupState.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/subcommands/operator/BackupState.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.cli.subcommands.operator;
 import static com.google.common.base.Preconditions.checkArgument;
 import static org.hyperledger.besu.cli.DefaultCommandValues.MANDATORY_LONG_FORMAT_HELP;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.cli.util.VersionProvider;
 import org.hyperledger.besu.controller.BesuController;
 import org.hyperledger.besu.ethereum.api.query.StateBackupService;
@@ -27,6 +26,7 @@ import org.hyperledger.besu.ethereum.eth.manager.EthScheduler;
 import org.hyperledger.besu.ethereum.trie.forest.ForestWorldStateArchive;
 import org.hyperledger.besu.ethereum.trie.forest.storage.ForestWorldStateKeyValueStorage;
 import org.hyperledger.besu.metrics.noop.NoOpMetricsSystem;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.io.File;
 import java.util.Optional;
@@ -92,7 +92,7 @@ public class BackupState implements Runnable {
       final long targetBlock = Math.min(blockchain.getChainHeadBlockNumber(), this.block);
       final StateBackupService backup =
           new StateBackupService(
-              BesuInfo.version(),
+              BesuVersionUtils.version(),
               blockchain,
               backupDir.toPath(),
               scheduler,

--- a/besu/src/main/java/org/hyperledger/besu/cli/util/VersionProvider.java
+++ b/besu/src/main/java/org/hyperledger/besu/cli/util/VersionProvider.java
@@ -14,8 +14,8 @@
  */
 package org.hyperledger.besu.cli.util;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.util.stream.Stream;
 
@@ -38,7 +38,8 @@ public class VersionProvider implements CommandLine.IVersionProvider {
   public String[] getVersion() {
     // the PluginVersionsProvider has registered plugins and their versions by this time.
     return Stream.concat(
-            Stream.of(BesuInfo.version()), pluginVersionsProvider.getPluginVersions().stream())
+            Stream.of(BesuVersionUtils.version()),
+            pluginVersionsProvider.getPluginVersions().stream())
         .toArray(String[]::new);
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/BesuCommandTest.java
@@ -51,7 +51,6 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.cli.config.EthNetworkConfig;
 import org.hyperledger.besu.cli.config.NativeRequirement.NativeRequirementResult;
 import org.hyperledger.besu.cli.config.NetworkName;
@@ -77,6 +76,7 @@ import org.hyperledger.besu.metrics.StandardMetricCategory;
 import org.hyperledger.besu.metrics.prometheus.MetricsConfiguration;
 import org.hyperledger.besu.plugin.data.EnodeURL;
 import org.hyperledger.besu.plugin.services.storage.DataStorageFormat;
+import org.hyperledger.besu.util.BesuVersionUtils;
 import org.hyperledger.besu.util.number.Fraction;
 import org.hyperledger.besu.util.number.Percentage;
 import org.hyperledger.besu.util.number.PositiveNumber;
@@ -251,7 +251,8 @@ public class BesuCommandTest extends CommandTestAbstract {
   @Test
   public void callingVersionDisplayBesuInfoVersion() {
     parseCommand("--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/PasswordSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/PasswordSubCommandTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.cli;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.hyperledger.besu.BesuInfo;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -67,14 +67,16 @@ public class PasswordSubCommandTest extends CommandTestAbstract {
   @Test
   public void passwordSubCommandVersionDisplaysVersion() {
     parseCommand("password", "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
   public void passwordHashSubCommandVersionDisplaysVersion() {
     parseCommand("password", "hash", "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/PublicKeySubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/PublicKeySubCommandTest.java
@@ -18,13 +18,13 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.crypto.KeyPair;
 import org.hyperledger.besu.crypto.SECPPrivateKey;
 import org.hyperledger.besu.crypto.SignatureAlgorithm;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
 import org.hyperledger.besu.cryptoservices.NodeKey;
 import org.hyperledger.besu.ethereum.core.Util;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -166,7 +166,8 @@ public class PublicKeySubCommandTest extends CommandTestAbstract {
   @Test
   public void callingPublicKeySubCommandVersionMustDisplayVersion() {
     parseCommand(PUBLIC_KEY_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
@@ -181,7 +182,8 @@ public class PublicKeySubCommandTest extends CommandTestAbstract {
   @Test
   public void callingPublicKeyExportSubCommandVersionMustDisplayVersion() {
     parseCommand(PUBLIC_KEY_SUBCOMMAND_NAME, PUBLIC_KEY_EXPORT_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
@@ -277,7 +279,8 @@ public class PublicKeySubCommandTest extends CommandTestAbstract {
   public void callingPublicKeyExportAddressSubCommandVersionMustDisplayVersion() {
     parseCommand(
         PUBLIC_KEY_SUBCOMMAND_NAME, PUBLIC_KEY_EXPORT_ADDRESS_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/ValidateConfigSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/ValidateConfigSubCommandTest.java
@@ -17,7 +17,7 @@ package org.hyperledger.besu.cli;
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
-import org.hyperledger.besu.BesuInfo;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.io.IOException;
 import java.net.URL;
@@ -65,7 +65,8 @@ public class ValidateConfigSubCommandTest extends CommandTestAbstract {
   @Test
   public void callingValidateConfigSubCommandVersionMustDisplayVersion() {
     parseCommand(VALIDATE_CONFIG_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/options/MiningOptionsTest.java
@@ -30,6 +30,7 @@ import org.hyperledger.besu.ethereum.core.MiningConfiguration;
 import org.hyperledger.besu.util.number.PositiveNumber;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.time.Duration;
 import java.util.Optional;
@@ -371,6 +372,16 @@ public class MiningOptionsTest extends AbstractCLIOptionsTest<MiningConfiguratio
         "--poa-block-txs-selection-max-time can be only used with PoA networks, see --block-txs-selection-max-time instead",
         "--poa-block-txs-selection-max-time",
         "90");
+  }
+
+  @Test
+  public void extraDataDefaultValueIsBesuVersion() {
+    final var expectedRegex = "besu \\d+\\.\\d+(\\.\\d+|\\-develop\\-\\p{XDigit}+)";
+    internalTestSuccess(
+        this::runtimeConfiguration,
+        miningParams ->
+            assertThat(new String(miningParams.getExtraData().toArray(), StandardCharsets.UTF_8))
+                .matches(expectedRegex));
   }
 
   @Override

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/blocks/BlocksSubCommandTest.java
@@ -24,9 +24,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.cli.CommandTestAbstract;
 import org.hyperledger.besu.controller.BesuController;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.io.File;
 import java.io.IOException;
@@ -143,7 +143,8 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
   @Test
   public void callingBlockSubCommandVersionMustDisplayVersion() {
     parseCommand(BLOCK_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
@@ -181,7 +182,8 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
   @Test
   public void callingBlockImportSubCommandVersionMustDisplayVersion() {
     parseCommand(BLOCK_SUBCOMMAND_NAME, BLOCK_IMPORT_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
@@ -477,7 +479,8 @@ public class BlocksSubCommandTest extends CommandTestAbstract {
   @Test
   public void callingBlockExportSubCommandVersionMustDisplayVersion() {
     parseCommand(BLOCK_SUBCOMMAND_NAME, BLOCK_EXPORT_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/operator/OperatorSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/operator/OperatorSubCommandTest.java
@@ -24,7 +24,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 import static org.hyperledger.besu.cli.subcommands.operator.OperatorSubCommandTest.Cmd.cmd;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.cli.CommandTestAbstract;
 import org.hyperledger.besu.crypto.SECP256K1;
 import org.hyperledger.besu.crypto.SECP256R1;
@@ -32,6 +31,7 @@ import org.hyperledger.besu.crypto.SECPPrivateKey;
 import org.hyperledger.besu.crypto.SECPPublicKey;
 import org.hyperledger.besu.crypto.SignatureAlgorithm;
 import org.hyperledger.besu.crypto.SignatureAlgorithmFactory;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.io.File;
 import java.io.FilenameFilter;
@@ -112,35 +112,40 @@ public class OperatorSubCommandTest extends CommandTestAbstract {
   @Test
   public void callingOperatorCommandVersionMustDisplayVersion() {
     parseCommand(OperatorSubCommand.COMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
   public void callingBackupStateCommandVersionMustDisplayVersion() {
     parseCommand("x-backup-state", "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
   public void callingGenerateBlockchainConfigCommandVersionMustDisplayVersion() {
     parseCommand("generate-blockchain-config", "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
   public void callingGenerateLogBloomCacheCommandVersionMustDisplayVersion() {
     parseCommand("generate-log-bloom-cache", "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
   public void callingRestoreStateCommandVersionMustDisplayVersion() {
     parseCommand("x-restore-state", "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/subcommands/rlp/RLPSubCommandTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/subcommands/rlp/RLPSubCommandTest.java
@@ -18,8 +18,8 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.contentOf;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.cli.CommandTestAbstract;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayInputStream;
@@ -107,14 +107,16 @@ public class RLPSubCommandTest extends CommandTestAbstract {
   @Test
   public void callingRPLSubCommandVersionMustDisplayVersion() {
     parseCommand(RLP_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 
   @Test
   public void callingRPLEncodeSubCommandVersionMustDisplayVersion() {
     parseCommand(RLP_SUBCOMMAND_NAME, RLP_ENCODE_SUBCOMMAND_NAME, "--version");
-    assertThat(commandOutput.toString(UTF_8)).isEqualToIgnoringWhitespace(BesuInfo.version());
+    assertThat(commandOutput.toString(UTF_8))
+        .isEqualToIgnoringWhitespace(BesuVersionUtils.version());
     assertThat(commandErrorOutput.toString(UTF_8)).isEmpty();
   }
 

--- a/besu/src/test/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactoryTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/util/BesuCommandCustomFactoryTest.java
@@ -17,8 +17,8 @@ package org.hyperledger.besu.cli.util;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.util.Arrays;
 
@@ -43,6 +43,7 @@ public class BesuCommandCustomFactoryTest {
     final BesuCommandCustomFactory besuCommandCustomFactory =
         new BesuCommandCustomFactory(pluginVersionsProvider);
     final VersionProvider versionProvider = besuCommandCustomFactory.create(VersionProvider.class);
-    assertThat(versionProvider.getVersion()).containsExactly(BesuInfo.version(), "v1", "v2");
+    assertThat(versionProvider.getVersion())
+        .containsExactly(BesuVersionUtils.version(), "v1", "v2");
   }
 }

--- a/besu/src/test/java/org/hyperledger/besu/cli/util/VersionProviderTest.java
+++ b/besu/src/test/java/org/hyperledger/besu/cli/util/VersionProviderTest.java
@@ -18,8 +18,8 @@ import static java.util.Collections.emptyList;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.plugin.services.PluginVersionsProvider;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import java.util.Collections;
 
@@ -37,13 +37,13 @@ public class VersionProviderTest {
   public void validateEmptyListGenerateBesuInfoVersionOnly() {
     when(pluginVersionsProvider.getPluginVersions()).thenReturn(emptyList());
     final VersionProvider versionProvider = new VersionProvider(pluginVersionsProvider);
-    assertThat(versionProvider.getVersion()).containsOnly(BesuInfo.version());
+    assertThat(versionProvider.getVersion()).containsOnly(BesuVersionUtils.version());
   }
 
   @Test
   public void validateVersionListGenerateValidValues() {
     when(pluginVersionsProvider.getPluginVersions()).thenReturn(Collections.singletonList("test"));
     final VersionProvider versionProvider = new VersionProvider(pluginVersionsProvider);
-    assertThat(versionProvider.getVersion()).containsExactly(BesuInfo.version(), "test");
+    assertThat(versionProvider.getVersion()).containsExactly(BesuVersionUtils.version(), "test");
   }
 }

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/MiningConfiguration.java
@@ -22,6 +22,7 @@ import org.hyperledger.besu.plugin.services.txselection.BlockTransactionSelectio
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelector;
 import org.hyperledger.besu.plugin.services.txselection.PluginTransactionSelectorFactory;
 import org.hyperledger.besu.plugin.services.txselection.SelectorsStateManager;
+import org.hyperledger.besu.util.BesuVersionUtils;
 import org.hyperledger.besu.util.number.PositiveNumber;
 
 import java.time.Duration;
@@ -34,8 +35,6 @@ import java.util.concurrent.TimeUnit;
 import com.google.common.annotations.VisibleForTesting;
 import org.apache.tuweni.bytes.Bytes;
 import org.immutables.value.Value;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
 
 @Value.Immutable
 @Value.Enclosing
@@ -215,23 +214,8 @@ public abstract class MiningConfiguration {
 
   @Value.Immutable
   public interface MutableInitValues {
-    // Obtain the raw short version
-    String RAW_SHORT_VERSION = MutableInitValues.class.getPackage().getImplementationVersion();;
-    // Strip everything from the first '-' or '+' onward 
-    // (handles both e.g. "v23.1.1-dev-ac23d311" or "v23.1.1+commit.abcd1234").
-    String SANITIZED_VERSION = RAW_SHORT_VERSION.replaceFirst("[-+].*", "");
-    // Build the extra-data string, e.g. "besu v25.4.0"
-    String VERSION_STRING = "besu " + SANITIZED_VERSION;
-    // Convert to UTF-8 bytes and cap at 32 bytes
-    byte[] VERSION_BYTES_ARR = VERSION_STRING.getBytes(UTF_8);
-    // If the byte array is longer than 32, truncate.
-    // We assume the first of version will be ASCII so partial characters won't be an issue
-    byte[] TRUNCATED_VERSION_BYTES = VERSION_BYTES_ARR.length > 32 
-        ? java.util.Arrays.copyOf(VERSION_BYTES_ARR, 32)
-        : VERSION_BYTES_ARR;
-
-    // This is the final default extra data, capped at 32 bytes.
-    Bytes DEFAULT_EXTRA_DATA = Bytes.wrap(TRUNCATED_VERSION_BYTES);
+    // This is the default extra data containing version info, capped at 32 bytes.
+    Bytes DEFAULT_EXTRA_DATA = BesuVersionUtils.versionForExtraData();
 
     Wei DEFAULT_MIN_TRANSACTION_GAS_PRICE = Wei.of(1000);
     Wei DEFAULT_MIN_PRIORITY_FEE_PER_GAS = Wei.ZERO;

--- a/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
+++ b/ethereum/core/src/main/java/org/hyperledger/besu/ethereum/core/VersionMetadata.java
@@ -14,6 +14,8 @@
  */
 package org.hyperledger.besu.ethereum.core;
 
+import org.hyperledger.besu.util.BesuVersionUtils;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -44,9 +46,7 @@ public class VersionMetadata implements Comparable<VersionMetadata> {
    * @return the version of Besu
    */
   public static String getRuntimeVersionString() {
-    return VersionMetadata.class.getPackage().getImplementationVersion() == null
-        ? BESU_VERSION_UNKNOWN
-        : VersionMetadata.class.getPackage().getImplementationVersion();
+    return BesuVersionUtils.version() == null ? BESU_VERSION_UNKNOWN : BesuVersionUtils.version();
   }
 
   public static VersionMetadata getRuntimeVersion() {

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/BenchmarkSubCommand.java
@@ -17,7 +17,6 @@ package org.hyperledger.besu.evmtool;
 import static org.hyperledger.besu.evmtool.BenchmarkSubCommand.COMMAND_NAME;
 import static picocli.CommandLine.ScopeType.INHERIT;
 
-import org.hyperledger.besu.BesuInfo;
 import org.hyperledger.besu.evm.precompile.AbstractBLS12PrecompiledContract;
 import org.hyperledger.besu.evm.precompile.AbstractPrecompiledContract;
 import org.hyperledger.besu.evmtool.benchmarks.AltBN128Benchmark;
@@ -26,6 +25,7 @@ import org.hyperledger.besu.evmtool.benchmarks.BenchmarkExecutor;
 import org.hyperledger.besu.evmtool.benchmarks.ECRecoverBenchmark;
 import org.hyperledger.besu.evmtool.benchmarks.ModExpBenchmark;
 import org.hyperledger.besu.evmtool.benchmarks.Secp256k1Benchmark;
+import org.hyperledger.besu.util.BesuVersionUtils;
 import org.hyperledger.besu.util.LogConfigurator;
 
 import java.io.PrintStream;
@@ -107,7 +107,7 @@ public class BenchmarkSubCommand implements Runnable {
   @Override
   public void run() {
     LogConfigurator.setLevel("", "DEBUG");
-    System.out.println(BesuInfo.version());
+    System.out.println(BesuVersionUtils.version());
     AbstractPrecompiledContract.setPrecompileCaching(enablePrecompileCache);
     AbstractBLS12PrecompiledContract.setPrecompileCaching(enablePrecompileCache);
     var benchmarksToRun = benchmarks.isEmpty() ? EnumSet.allOf(Benchmark.class) : benchmarks;

--- a/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/VersionProvider.java
+++ b/ethereum/evmtool/src/main/java/org/hyperledger/besu/evmtool/VersionProvider.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.evmtool;
 
-import org.hyperledger.besu.BesuInfo;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import picocli.CommandLine;
 
@@ -42,6 +42,6 @@ public class VersionProvider implements CommandLine.IVersionProvider {
     // This version string is used in the execution spec tests to identify the client.
     // If modified, update the `detect_binary_pattern` variable in the following repository:
     // https://github.com/ethereum/execution-spec-tests/blob/main/src/ethereum_clis/clis/besu.py
-    return new String[] {"Besu evm " + BesuInfo.shortVersion()};
+    return new String[] {"Besu evm " + BesuVersionUtils.shortVersion()};
   }
 }

--- a/testfuzz/src/main/java/org/hyperledger/besu/testfuzz/VersionProvider.java
+++ b/testfuzz/src/main/java/org/hyperledger/besu/testfuzz/VersionProvider.java
@@ -14,7 +14,7 @@
  */
 package org.hyperledger.besu.testfuzz;
 
-import org.hyperledger.besu.BesuInfo;
+import org.hyperledger.besu.util.BesuVersionUtils;
 
 import picocli.CommandLine;
 
@@ -42,6 +42,6 @@ public class VersionProvider implements CommandLine.IVersionProvider {
    */
   @Override
   public String[] getVersion() {
-    return new String[] {"Hyperledger Besu evm " + BesuInfo.shortVersion()};
+    return new String[] {"Hyperledger Besu evm " + BesuVersionUtils.shortVersion()};
   }
 }

--- a/util/build.gradle
+++ b/util/build.gradle
@@ -35,6 +35,7 @@ dependencies {
   annotationProcessor 'org.apache.logging.log4j:log4j-core'
 
   implementation 'com.google.guava:guava'
+  implementation 'io.consensys.tuweni:tuweni-bytes'
   implementation 'net.java.dev.jna:jna'
   implementation 'org.apache.commons:commons-lang3'
   implementation 'org.apache.logging.log4j:log4j-core'

--- a/util/src/main/java/org/hyperledger/besu/util/BesuVersionUtils.java
+++ b/util/src/main/java/org/hyperledger/besu/util/BesuVersionUtils.java
@@ -12,30 +12,34 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu;
+package org.hyperledger.besu.util;
 
 import org.hyperledger.besu.util.platform.PlatformDetector;
 
 import java.net.JarURLConnection;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.util.Optional;
 import java.util.jar.Attributes;
 import java.util.jar.Manifest;
+
+import org.apache.tuweni.bytes.Bytes;
 
 /**
  * Represent Besu information such as version, OS etc. Used with --version option and during Besu
  * start.
  */
-public final class BesuInfo {
+public final class BesuVersionUtils {
   private static final String CLIENT = "besu";
-  private static final String VERSION = BesuInfo.class.getPackage().getImplementationVersion();
+  private static final String VERSION =
+      BesuVersionUtils.class.getPackage().getImplementationVersion();
   private static final String OS = PlatformDetector.getOS();
   private static final String VM = PlatformDetector.getVM();
   private static final String COMMIT;
 
   static {
-    String className = BesuInfo.class.getSimpleName() + ".class";
-    String classPath = BesuInfo.class.getResource(className).toString();
+    String className = BesuVersionUtils.class.getSimpleName() + ".class";
+    String classPath = BesuVersionUtils.class.getResource(className).toString();
 
     String commit;
     try {
@@ -50,7 +54,7 @@ public final class BesuInfo {
     COMMIT = commit;
   }
 
-  private BesuInfo() {}
+  private BesuVersionUtils() {}
 
   /**
    * Generate version-only Besu version
@@ -59,6 +63,17 @@ public final class BesuInfo {
    */
   public static String shortVersion() {
     return VERSION;
+  }
+
+  /**
+   * Generate version suitable to be used in the extra data field of a block header
+   *
+   * @return Besu version in format such as "v23.1.0" or "v23.1.1-dev-ac23d311" as UTF-8 encoded
+   *     bytes
+   */
+  public static Bytes versionForExtraData() {
+    final var nameAndVersion = ("besu " + VERSION).getBytes(StandardCharsets.UTF_8);
+    return Bytes.wrap(nameAndVersion, 0, Math.min(32, nameAndVersion.length));
   }
 
   /**

--- a/util/src/test/java/org/hyperledger/besu/util/BesuVersionUtilsTest.java
+++ b/util/src/test/java/org/hyperledger/besu/util/BesuVersionUtilsTest.java
@@ -12,7 +12,7 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  */
-package org.hyperledger.besu;
+package org.hyperledger.besu.util;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-public final class BesuInfoTest {
+public final class BesuVersionUtilsTest {
 
   /**
    * Ethstats wants a version string like &lt;foo&gt/v&lt;bar&gt/&lt;baz&gt/&lt;bif&gt. Foo is the
@@ -33,7 +33,8 @@ public final class BesuInfoTest {
    */
   @Test
   public void versionStringIsEthstatsFriendly() {
-    assertThat(BesuInfo.version()).matches("[^/]+/v(\\d+\\.\\d+\\.\\d+[^/]*|null)/[^/]+/[^/]+");
+    assertThat(BesuVersionUtils.version())
+        .matches("[^/]+/v(\\d+\\.\\d+\\.\\d+[^/]*|null)/[^/]+/[^/]+");
   }
 
   /**
@@ -44,7 +45,7 @@ public final class BesuInfoTest {
    */
   @Test
   public void noIdentityNodeNameIsEthstatsFriendly() {
-    assertThat(BesuInfo.nodeName(Optional.empty()))
+    assertThat(BesuVersionUtils.nodeName(Optional.empty()))
         .matches("[^/]+/v(\\d+\\.\\d+\\.\\d+[^/]*|null)/[^/]+/[^/]+");
   }
 
@@ -57,7 +58,7 @@ public final class BesuInfoTest {
    */
   @Test
   public void userIdentityNodeNameIsEthstatsFriendly() {
-    assertThat(BesuInfo.nodeName(Optional.of("TestUserIdentity")))
+    assertThat(BesuVersionUtils.nodeName(Optional.of("TestUserIdentity")))
         .matches("[^/]+/[^/]+/v(\\d+\\.\\d+\\.\\d+[^/]*|null)/[^/]+/[^/]+");
   }
 }


### PR DESCRIPTION
## PR description

This way all the version management is centralized in one place

## Fixed Issue(s)
<!-- Please link to fixed issue(s) here using format: fixes #<issue number> -->
<!-- Example: "fixes #2" -->


### Thanks for sending a pull request! Have you done the following?

- [ ] Checked out our [contribution guidelines](https://github.com/hyperledger/besu/blob/main/CONTRIBUTING.md)?
- [ ] Considered documentation and added the `doc-change-required` label to this PR [if updates are required](https://wiki.hyperledger.org/display/BESU/Documentation).
- [ ] Considered the changelog and included an [update if required](https://wiki.hyperledger.org/display/BESU/Changelog).
- [ ] For database changes (e.g. KeyValueSegmentIdentifier) considered compatibility and performed forwards and backwards compatibility tests

### Locally, you can run these tests to catch failures early:

- [ ] spotless: `./gradlew spotlessApply`
- [ ] unit tests: `./gradlew build`
- [ ] acceptance tests: `./gradlew acceptanceTest`
- [ ] integration tests: `./gradlew integrationTest`
- [ ] reference tests: `./gradlew ethereum:referenceTests:referenceTests`

